### PR TITLE
Test nonexistent secrets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'hiera', '1.3.4'
 gem 'aws-sdk-secretsmanager'
+gem 'hiera', '1.3.4'
 
 group :test, :development do
   gem 'mocha'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
 gem 'hiera', '1.3.4'
-gem 'mocha'
-gem 'rake'
 gem 'aws-sdk-secretsmanager'
+
+group :test, :development do
+  gem 'mocha'
+  gem 'rake'
+  gem 'rspec'
+  gem 'rubocop'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.100.0)
     aws-sdk-core (3.24.1)
@@ -15,11 +16,17 @@ GEM
     diff-lcs (1.3)
     hiera (1.3.4)
       json_pure
+    jaro_winkler (1.5.1)
     jmespath (1.4.0)
     json_pure (2.1.0)
     metaclass (0.0.4)
     mocha (1.7.0)
       metaclass (~> 0.0.1)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
     rake (12.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -34,6 +41,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.10.0)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -44,6 +61,7 @@ DEPENDENCIES
   mocha
   rake
   rspec
+  rubocop
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
-require "rake"
-require "rspec/core/rake_task"
+require 'rake'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = Dir.glob("spec/**/*_spec.rb")
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
 end
 task default: :spec

--- a/lib/secrets_manager_backend.rb
+++ b/lib/secrets_manager_backend.rb
@@ -1,35 +1,27 @@
 class Hiera
   module Backend
     class Secrets_manager_backend
-      def initialize()
+      def initialize
         require 'aws-sdk-secretsmanager'
 
         # Initialises a new instance of the AWS Secrets Manager client
-        @client = Aws::SecretsManager::Client.new(region: Config[:secrets_manager][:region])
+        @client = Aws::SecretsManager::Client.new(
+          region: Config[:secrets_manager][:region]
+        )
 
-        Hiera.debug("AWS Secrets Manager backend starting")
+        Hiera.debug('AWS Secrets Manager backend starting')
       end
 
-      # lookup() is called by Hiera to return a secret, and is required by Hiera to work
       def lookup(key, scope, order_override, resolution_type)
-
-        # If lookup() returns `nil`, it will proceed to the next available backend (possible Hiera)
         answer = nil
 
-        # begin / rescue / end is like a try / catch,
-        # and will ensure Hiera doesn't break if the Secrets Manager library doesn't work properly
         begin
+          answer = @client.get_secret_value(secret_id: key)['secret_string']
 
-          # queries Secrets Manager for the value of the key passed
-          # 'secret_string' contains the actual plaintext secret
-          answer = @client.get_secret_value({secret_id: key})['secret_string']
-
-        #   Catches any errors, and outputs a debug message
         rescue Aws::SecretsManager::Errors::ResourceNotFoundException => error
           Hiera.debug("#{key} not found: #{error.message}")
         end
 
-        # Implicitly returns answer, which will either be nil or the actual answer!
         answer
       end
     end

--- a/spec/secrets_manager_backend_spec.rb
+++ b/spec/secrets_manager_backend_spec.rb
@@ -5,53 +5,68 @@ class Hiera
   module Backend
     describe Secrets_manager_backend do
       before do
-        @config_object = { :secrets_manager => { :region => "some_region" } }
+        @config_object = { secrets_manager: { region: 'some_region' } }
         Config.load(@config_object)
         Hiera.stubs(:debug)
-        Aws::SecretsManager::Client.stubs(:new).with(@config_object[:secrets_manager])
+        Aws::SecretsManager::Client
+          .stubs(:new)
+          .with(@config_object[:secrets_manager])
       end
 
-      describe "#initialize" do
-        it "should announce its creation" do
-          Hiera.expects(:debug).with("AWS Secrets Manager backend starting")
+      describe '#initialize' do
+        it 'should announce its creation' do
+          Hiera
+            .expects(:debug)
+            .with('AWS Secrets Manager backend starting')
           Secrets_manager_backend.new
         end
 
-        it "should set up a connection to AWS Secrets Manager" do
-          Aws::SecretsManager::Client.expects(:new).with(@config_object[:secrets_manager])
+        it 'should set up a connection to AWS Secrets Manager' do
+          Aws::SecretsManager::Client
+            .expects(:new)
+            .with(@config_object[:secrets_manager])
           Secrets_manager_backend.new
         end
-
       end
 
       describe '#lookup' do
         before do
           @mock_client = mock('client')
-          Aws::SecretsManager::Client.stubs(:new).with(@config_object[:secrets_manager]).returns(@mock_client)
+          Aws::SecretsManager::Client
+            .stubs(:new)
+            .with(@config_object[:secrets_manager]).returns(@mock_client)
           @backend = Secrets_manager_backend.new
         end
 
-        it "should return a secret that exists" do
-          secret_name = "secret_name"
-          secret_string = "i_am_a_secret"
+        it 'should return a secret that exists' do
+          secret_name = 'secret_name'
+          secret_string = 'i_am_a_secret'
 
           @mock_client.stubs(:get_secret_value)
-              .with({ secret_id: secret_name })
-              .returns('secret_string' => secret_string)
+                      .with(secret_id: secret_name)
+                      .returns('secret_string' => secret_string)
 
           answer = @backend.lookup(secret_name, nil, nil, nil)
           expect(answer).to eq(secret_string)
         end
 
-        it "should not return a secret that does not exist" do
-          nonexistent_secret = "does_not_exist"
+        it 'should not return a secret that does not exist' do
+          nonexistent_secret = 'does_not_exist'
           mock_context = {}
           error_message = 'Secrets Manager could not find this secret.'
+          error = Aws::
+                  SecretsManager::
+                  Errors::
+                  ResourceNotFoundException.new(
+                    mock_context,
+                    error_message
+                  )
           @mock_client.stubs(:get_secret_value)
-              .with({ secret_id: nonexistent_secret })
-              .raises(Aws::SecretsManager::Errors::ResourceNotFoundException.new(mock_context, error_message))
-
-          Hiera.expects(:debug).with("#{nonexistent_secret} not found: #{error_message}")
+                      .with(secret_id: nonexistent_secret)
+                      .raises(error)
+          Hiera
+            .expects(:debug)
+            .with("#{nonexistent_secret} not found: #{error_message}")
           answer = @backend.lookup(nonexistent_secret, nil, nil, nil)
           expect(answer).to eq(nil)
         end

--- a/spec/secrets_manager_backend_spec.rb
+++ b/spec/secrets_manager_backend_spec.rb
@@ -12,7 +12,6 @@ class Hiera
       end
 
       describe "#initialize" do
-
         it "should announce its creation" do
           Hiera.expects(:debug).with("AWS Secrets Manager backend starting")
           Secrets_manager_backend.new
@@ -33,27 +32,27 @@ class Hiera
         end
 
         it "should return a secret that exists" do
-          @secret_name = "secret_name"
-          @secret_string = "i_am_a_secret"
+          secret_name = "secret_name"
+          secret_string = "i_am_a_secret"
 
           @mock_client.stubs(:get_secret_value)
-              .with({ secret_id: @secret_name })
-              .returns('secret_string' => @secret_string)
+              .with({ secret_id: secret_name })
+              .returns('secret_string' => secret_string)
 
-          answer = @backend.lookup(@secret_name, nil, nil, nil)
-          expect(answer).to eq(@secret_string)
+          answer = @backend.lookup(secret_name, nil, nil, nil)
+          expect(answer).to eq(secret_string)
         end
 
         it "should not return a secret that does not exist" do
-          @nonexistent_secret = "does_not_exist"
-          @mock_context = {}
-          @error_message = 'Secrets Manager could not find this secret.'
+          nonexistent_secret = "does_not_exist"
+          mock_context = {}
+          error_message = 'Secrets Manager could not find this secret.'
           @mock_client.stubs(:get_secret_value)
-              .with({ secret_id: @nonexistent_secret })
-              .raises(Aws::SecretsManager::Errors::ResourceNotFoundException.new(@mock_context, @error_message))
+              .with({ secret_id: nonexistent_secret })
+              .raises(Aws::SecretsManager::Errors::ResourceNotFoundException.new(mock_context, error_message))
 
-          Hiera.expects(:debug).with("#{@nonexistent_secret} not found: #{@error_message}")
-          answer = @backend.lookup(@nonexistent_secret, nil, nil, nil)
+          Hiera.expects(:debug).with("#{nonexistent_secret} not found: #{error_message}")
+          answer = @backend.lookup(nonexistent_secret, nil, nil, nil)
           expect(answer).to eq(nil)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$:.insert(0, File.join([File.dirname(__FILE__), "..", "lib"]))
+$LOAD_PATH.insert(0, File.join([File.dirname(__FILE__), '..', 'lib']))
 
 require 'rubygems'
 require 'rspec'


### PR DESCRIPTION
- Add tests to ensure correct error message is raised when querying a nonexistent credential.
- Update code to obey Rubocop linting rules.